### PR TITLE
[Task-4] Build a custom validator for movie titles

### DIFF
--- a/app/models/concerns/title_brackets_validator.rb
+++ b/app/models/concerns/title_brackets_validator.rb
@@ -1,0 +1,43 @@
+class TitleBracketsValidator < ActiveModel::Validator
+  def validate(movie)
+    title = movie.title
+    @stack = []
+
+    title.each_char.with_index do |char, index|
+      if opening_brace?(char)
+        @stack.push(char)
+      elsif closing_brace?(char)
+        if closes_last_opening_brace?(char)
+          movie.errors.add(:title, "Empty brackets") if title.index(last_opening_brace) == index - 1
+          @stack.pop
+        else
+          movie.errors.add(:title, "Incorrect closing bracket")
+          return
+        end
+      end
+    end
+    movie.errors.add(:title, "Unclosed opening bracket") if @stack.any?
+  end
+
+  private
+  
+  def opening_brace?(char)
+    ["{", "[", "("].include?(char)
+  end
+
+  def closing_brace?(char)
+    ["}", "]", ")"].include?(char)
+  end
+
+  def last_opening_brace
+    @stack.last
+  end
+
+  def opening_brace_of(char)
+    { "}" => "{", ")" => "(", "]" => "["}[char]
+  end
+
+  def closes_last_opening_brace?(char)
+    opening_brace_of(char) == last_opening_brace
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,4 +14,6 @@
 
 class Movie < ApplicationRecord
   belongs_to :genre
+
+  validates_with TitleBracketsValidator
 end

--- a/spec/validators/title_brackets_validator_spec.rb
+++ b/spec/validators/title_brackets_validator_spec.rb
@@ -1,87 +1,87 @@
-# require "rails_helper"
+require "rails_helper"
 
-# describe TitleBracketsValidator do
-#   subject { Validatable.new(title: title) }
+describe TitleBracketsValidator do
+  subject { Validatable.new(title: title) }
 
-#   shared_examples "has valid title" do
-#     it "should be valid" do
-#       expect(subject).to be_valid
-#     end
-#   end
+  shared_examples "has valid title" do
+    it "should be valid" do
+      expect(subject).to be_valid
+    end
+  end
 
-#   shared_examples "has invalid title" do
-#     it "should not be valid" do
-#       expect(subject).not_to be_valid
-#     end
-#   end
+  shared_examples "has invalid title" do
+    it "should not be valid" do
+      expect(subject).not_to be_valid
+    end
+  end
 
-#   context "with curly brackets" do
-#     let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with curly brackets" do
+    let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with square brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with square brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with not closed brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not closed brackets" do
+    let(:title) { "The Fellowship of the Ring (2001" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not opened brackets" do
-#     let(:title) { "The Fellowship of the Ring 2001)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not opened brackets" do
+    let(:title) { "The Fellowship of the Ring 2001)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much closing brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much closing brackets" do
+    let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much opening brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much opening brackets" do
+    let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with empty brackets" do
-#     let(:title) { "The Fellowship of the Ring ()" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with empty brackets" do
+    let(:title) { "The Fellowship of the Ring ()" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with brackets in wrong order" do
-#     let(:title) { "The Fellowship of the )Ring(" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with brackets in wrong order" do
+    let(:title) { "The Fellowship of the )Ring(" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with matching brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with matching brackets" do
+    let(:title) { "The Fellowship of the Ring (2001)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with multiple matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with multiple matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with nested matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with nested matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with no brackets" do
-#     let(:title) { "Lord of The Rings" }
-#     it_behaves_like "has valid title"
-#   end
-# end
+  context "with no brackets" do
+    let(:title) { "Lord of The Rings" }
+    it_behaves_like "has valid title"
+  end
+end
 
-# class Validatable
-#   include ActiveModel::Validations
-#   validates_with TitleBracketsValidator
-#   attr_accessor :title
+class Validatable
+  include ActiveModel::Validations
+  validates_with TitleBracketsValidator
+  attr_accessor :title
 
-#   def initialize(title:)
-#     @title = title
-#   end
-# end
+  def initialize(title:)
+    @title = title
+  end
+end


### PR DESCRIPTION
#### Why you made this change:
I introduced this feature to prevent administrators from entering movie titles with incorrect brackets in them.

#### How the change addresses the need:
I wrote a custom validator for movie titles which is in essence a linter that checks titles for correct brackets, i.e. it doesn't allow the admin to save a movie title where brackets are mismatched, not closed or empty. 

#### Testing procedure:
Run ``RAILS_ENV=test bundle exec rspec spec/validators/title_brackets_validator_spec.rb``
It should be green.